### PR TITLE
Minor quality fixes, new training mode using multiple seeds on single generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,9 @@ log/*.log
 data/*
 
 # unnecessary folders
+.cache/*
 bin/*
 */obj/*
 .vscode/*
 .clang-format
+compile_commands.json

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 # compiler and linker flags
 CC = clang
 CFLAGS = -Wall -Wextra -Wpedantic -Werror -Wshadow -Wstrict-overflow -fno-strict-aliasing -std=gnu11 -pthread -D_DEFAULT_SOURCE
-LDFLAGS = -lraylib -lm -lpthread -lrt -lX11 -lGL -lm -lpthread -ldl
+LDFLAGS = -lraylib -lm -lpthread -lrt -lX11 -lGL -lm -ldl
 
+# determining which build to use (release, debug or sanitizer)
 SANITIZER ?= 0
 DEBUG ?= 0
 ifeq ($(SANITIZER), 1)
@@ -42,48 +43,30 @@ BIN_DIR = bin
 
 .PHONY: all common game manager neurons clean
 
-all: game manager neurons
-
-# test target which prints out all above defined variables
-test_vars: | $(BIN_DIR)
-	@echo COMMON_DIR: $(COMMON_DIR)
-	@echo COMMON_SRC: $(COMMON_SRC)
-	@echo COMMON_OBJS: $(COMMON_OBJS)
-	@echo GAME_DIR: $(GAME_DIR)
-	@echo GAME_SRC: $(GAME_SRC)
-	@echo GAME_OBJS: $(GAME_OBJS)
-	@echo MANAGER_DIR: $(MANAGER_DIR)
-	@echo MANAGER_SRC: $(MANAGER_SRC)
-	@echo MANAGER_OBJS: $(MANAGER_OBJS)
-	@echo NEURONS_DIR: $(NEURONS_DIR)
-	@echo NEURONS_SRC: $(NEURONS_SRC)
-	@echo NEURONS_OBJS: $(NEURONS_OBJS)
-	@echo BIN_DIR: $(BIN_DIR)
+all: common game manager neurons
 
 common: $(COMMON_OBJS)
 
-game: $(COMMON_OBJS) $(GAME_OBJS) | $(BIN_DIR)
+game: $(GAME_OBJS) $(COMMON_OBJS) | $(BIN_DIR)
 	$(CC) -o $(BIN_DIR)/game $(COMMON_OBJS) $(GAME_OBJS) $(LDFLAGS)
 
-manager: $(COMMON_OBJS) $(MANAGER_OBJS) | $(BIN_DIR)
+manager: $(MANAGER_OBJS) $(COMMON_OBJS) | $(BIN_DIR)
 	$(CC) -o $(BIN_DIR)/manager $(COMMON_OBJS) $(MANAGER_OBJS) $(LDFLAGS)
 
-neurons: $(COMMON_OBJS) $(NEURONS_OBJS) | $(BIN_DIR)
+neurons: $(NEURONS_OBJS) $(COMMON_OBJS) | $(BIN_DIR)
 	$(CC) -o $(BIN_DIR)/neurons $(COMMON_OBJS) $(NEURONS_OBJS) $(LDFLAGS)
 
-#$(GAME_OBJS) $(MANAGER_OBJS) $(NEURONS_OBJS): | $(COMMON_OBJS)
-
 $(COMMON_DIR)/obj/%.o:
-	$(MAKE) -C common build
+	$(MAKE) -C common $(patsubst $(COMMON_DIR)/obj/%.o,obj/%.o,$@)
 
 $(GAME_DIR)/obj/%.o:
-	$(MAKE) -C game build
+	$(MAKE) -C game $(patsubst $(GAME_DIR)/obj/%.o,obj/%.o,$@)
 
 $(MANAGER_DIR)/obj/%.o:
-	$(MAKE) -C manager build
+	$(MAKE) -C manager $(patsubst $(MANAGER_DIR)/obj/%.o,obj/%.o,$@)
 
 $(NEURONS_DIR)/obj/%.o:
-	$(MAKE) -C neurons build
+	$(MAKE) -C neurons $(patsubst $(NEURONS_DIR)/obj/%.o,obj/%.o,$@)
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)
@@ -108,4 +91,3 @@ help:
 	@echo "  clean    Remove all generated files"
 	@echo "  help     Show this help message"
 
-#vpath %.o $(COMMON_DIR) $(GAME_DIR) $(MANAGER_DIR) $(NEURONS_DIR)

--- a/common/include/xArray.h
+++ b/common/include/xArray.h
@@ -17,8 +17,6 @@
 extern "C" {
 #endif
 
-#include <stdlib.h>
-
 /**
  * @brief
  * xArray object which contains data, size and capacity.

--- a/common/include/xList.h
+++ b/common/include/xList.h
@@ -16,8 +16,6 @@
 extern "C" {
 #endif
 
-#include <stdlib.h>
-
 /**
  * @brief
  * Linked list node structure which contains data and pointers to next and previous node. If there is no next or previous node, pointer is NULL.

--- a/common/include/xStringIO.h
+++ b/common/include/xStringIO.h
@@ -15,9 +15,8 @@
 #ifndef XSTRINGIO_H
 #define XSTRINGIO_H
 
-#include <stdio.h>  // file and stream I/O
-
-#include "xString.h"  // base xString module
+#include <stdio.h>    // file and stream I/O
+#include "xString.h"  // base xString library
 
 #ifdef __cplusplus
 extern "C" {

--- a/common/src/commonUtility.c
+++ b/common/src/commonUtility.c
@@ -1,6 +1,5 @@
 #include "commonUtility.h"
-
-#include <stdlib.h>
+#include <stdlib.h>  // standard library (for malloc, free, realloc)
 
 int cu_CStringCompare(const char *str1, const char *str2)
 {

--- a/common/src/fnnSerializer.c
+++ b/common/src/fnnSerializer.c
@@ -1,8 +1,7 @@
 #include "fnnSerializer.h"
-
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <stdint.h>  // standard integer types for fixed integer width in file format (uint32_t, ...)
+#include <stdio.h>   // standard I/O (fprintf, ...)
+#include <stdlib.h>  // standard library (for malloc, free, ...)
 
 FnnModel *fnn_new(void)
 {

--- a/common/src/sharedMemory.c
+++ b/common/src/sharedMemory.c
@@ -1,13 +1,12 @@
 #include "sharedMemory.h"
-
-#include <fcntl.h>
-#include <pthread.h>
-#include <stdbool.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <unistd.h>
+#include <fcntl.h>     // file control option flags (O_CREAT, O_RDWR)
+#include <pthread.h>   // POSIX threads (mutex)
+#include <stdbool.h>   // boolean type (true, false values)
+#include <stdio.h>     // standard I/O (perror, ...)
+#include <stdlib.h>    // standard library (exit, ...)
+#include <sys/mman.h>  // memory management (mmap, munmap)
+#include <sys/stat.h>  // status of file or file system (for mode constants)
+#include <unistd.h>    // standard symbolic constants and types (for POSIX OS API)
 
 int sm_validateSharedMemoryName(const char *sharedMemoryName)
 {

--- a/common/src/xArray.c
+++ b/common/src/xArray.c
@@ -1,6 +1,5 @@
 #include "xArray.h"
-
-#include <stdlib.h>
+#include <stdlib.h>  // standard library (for malloc, free)
 
 // DISABLED BECAUSE OF ISSUES
 /*
@@ -172,9 +171,9 @@ void xArray_sort(xArray *arr, int (*comparator)(const void *, const void *))
     }
     // xArray_quicksort(arr->data, arr->size, comparator);
 
-    for(int i = 0; i < arr->size; i++) {
-        for(int j = i + 1; j < arr->size; j++) {
-            if(comparator(arr->data[i], arr->data[j]) > 0) {
+    for (int i = 0; i < arr->size; i++) {
+        for (int j = i + 1; j < arr->size; j++) {
+            if (comparator(arr->data[i], arr->data[j]) > 0) {
                 xArray_swap(arr, i, j);
             }
         }

--- a/common/src/xDictionary.c
+++ b/common/src/xDictionary.c
@@ -1,6 +1,5 @@
 #include "xDictionary.h"
-
-#include <stdlib.h>
+#include <stdlib.h>  // standard library (for malloc, free, realloc)
 
 xDictionary *xDictionary_new(void)
 {

--- a/common/src/xList.c
+++ b/common/src/xList.c
@@ -1,6 +1,5 @@
 #include "xList.h"
-
-#include <stdlib.h>
+#include <stdlib.h>  // standard library (for malloc, free)
 
 xList *xList_new(void)
 {

--- a/common/src/xString.c
+++ b/common/src/xString.c
@@ -1,6 +1,5 @@
 #include "xString.h"
-
-#include <stdlib.h>
+#include <stdlib.h>  // standard library (for malloc, free)
 
 xString *xString_new(void)
 {

--- a/common/src/xStringIO.c
+++ b/common/src/xStringIO.c
@@ -1,9 +1,7 @@
-#include "xStringIO.h"  // base header
-
-#include <stdio.h>   // file and stream I/O
-#include <stdlib.h>  // dynamic memory management
-
-#include "xString.h"  // base xString module
+#include "xStringIO.h"
+#include <stdio.h>    // standard I/O functions
+#include <stdlib.h>   // standard library (for malloc, free, ...)
+#include "xString.h"  // base xString library
 
 xString *xString_readStream(FILE *stream)
 {

--- a/game/include/gameMain.h
+++ b/game/include/gameMain.h
@@ -12,7 +12,7 @@
 #ifndef MAIN_H
 #define MAIN_H
 
-#include <raylib.h>
+#include <raylib.h>  // raylib library
 
 // ------------------------------------------------------------------
 // game enum definitions

--- a/game/src/gameMain.c
+++ b/game/src/gameMain.c
@@ -417,7 +417,7 @@ static inline void UpdateSharedOutput(void)
         shOutput->gameOutput01 = player.rotation / PI;
         shOutput->gameOutput02 = relativeVelocity.x / (ASTEROID_SPEED + PLAYER_MAX_SPEED);
         shOutput->gameOutput03 = relativeVelocity.y / (ASTEROID_SPEED + PLAYER_MAX_SPEED);
-        shOutput->gameOutput04 = closestAsteroid.x / screenDiagonal;
+        shOutput->gameOutput04 = (closestAsteroid.x - player.collider.z) / screenDiagonal;
         shOutput->gameOutput05 = closestAsteroid.y / PI;
         sm_unlockSharedOutput(shOutput);
     }
@@ -502,7 +502,7 @@ static Vector2 ClosestAsteroid(void)
                                 (Vector2){asteroid->position.x - screenWidth, asteroid->position.y + screenHeight}};
 
         for (int j = 0; j < (int)(sizeof(positions) / sizeof(Vector2)); j++) {
-            float distance = Vector2Distance(player.position, positions[j]);
+            float distance = Vector2Distance(player.position, positions[j]) - asteroid->radius;
             if (distance < minDistance) {
                 minDistance = distance;
                 deltaRotation = atan2f(positions[j].y - player.position.y, positions[j].x - player.position.x) - player.rotation;
@@ -680,8 +680,8 @@ static void UpdateGame(void)
             }
 
             // asteroid logic
-            player.collider = (Vector3){player.position.x + cosf(player.rotation) * (shipHeight / 2.5f),
-                                        player.position.y + sinf(player.rotation) * (shipHeight / 2.5f), 12};
+            player.collider = (Vector3){player.position.x /* + cosf(player.rotation) * (shipHeight / 2.5f)*/,
+                                        player.position.y /* + sinf(player.rotation) * (shipHeight / 2.5f)*/, 12};
             for (int i = 0; i < asteroids->size; i++) {
                 Asteroid *asteroid = (Asteroid *)xArray_get(asteroids, i);
                 if (!asteroid->active)
@@ -793,12 +793,14 @@ static void DrawGame(void)
 
     if (!gameOver) {
         // Draw spaceship
-        Vector2 v1 = {player.position.x + cosf(player.rotation) * (shipHeight),
-                      player.position.y + sinf(player.rotation) * (shipHeight)};
-        Vector2 v2 = {player.position.x + sinf(player.rotation) * (PLAYER_BASE_SIZE / 2),
-                      player.position.y - cosf(player.rotation) * (PLAYER_BASE_SIZE / 2)};
-        Vector2 v3 = {player.position.x - sinf(player.rotation) * (PLAYER_BASE_SIZE / 2),
-                      player.position.y + cosf(player.rotation) * (PLAYER_BASE_SIZE / 2)};
+        Vector2 v1 = {player.position.x + cosf(player.rotation) * (shipHeight) * 0.5f,
+                      player.position.y + sinf(player.rotation) * (shipHeight) * 0.5f};
+        Vector2 v2 = {
+            player.position.x + sinf(player.rotation) * (PLAYER_BASE_SIZE / 2) - cosf(player.rotation) * (shipHeight) * 0.5f,
+            player.position.y - cosf(player.rotation) * (PLAYER_BASE_SIZE / 2) - sinf(player.rotation) * (shipHeight) * 0.5f};
+        Vector2 v3 = {
+            player.position.x - sinf(player.rotation) * (PLAYER_BASE_SIZE / 2) - cosf(player.rotation) * (shipHeight) * 0.5f,
+            player.position.y + cosf(player.rotation) * (PLAYER_BASE_SIZE / 2) - sinf(player.rotation) * (shipHeight) * 0.5f};
         DrawTriangleLines(v1, v2, v3, player.color);
 
         // Draw asteroids

--- a/game/src/gameMain.c
+++ b/game/src/gameMain.c
@@ -1,14 +1,12 @@
-#include "gameMain.h"  // game enums, structs, constant definitions, etc.
-
-#include <fcntl.h>    // file control options (open, close, etc.)
-#include <raylib.h>   // graphics library
-#include <raymath.h>  // math library
-#include <signal.h>   // signal handling library
-#include <stdio.h>    // standard input/output library
-#include <stdlib.h>   // standard library (malloc, free, etc.)
-#include <time.h>     // time library (game logic timer and random seed)
-#include <unistd.h>   // UNIX standard library (fork, exec, etc.)
-
+#include "gameMain.h"       // game enums, structs, constant definitions, etc.
+#include <fcntl.h>          // file control options (open, close, etc.)
+#include <raylib.h>         // graphics library
+#include <raymath.h>        // math library
+#include <signal.h>         // signal handling library
+#include <stdio.h>          // standard input/output library
+#include <stdlib.h>         // standard library (malloc, free, etc.)
+#include <time.h>           // time library (game logic timer and random seed)
+#include <unistd.h>         // UNIX standard library (fork, exec, etc.)
 #include "commonUtility.h"  // smaller utility functions which don't belong in any standalone module
 #include "sharedMemory.h"   //shared memory interfaces and functions (IPC)
 #include "xArray.h"         // dynamic array library
@@ -470,7 +468,8 @@ static inline void PregenAsteroids(void)
         float randomAngle = (rand() & 360) * DEG2RAD;
 
         newAsteroid->position = (Vector2){posx, posy};
-        newAsteroid->speed = Vector2Scale((Vector2){cosf(randomAngle), sinf(randomAngle)}, ASTEROID_SPEED);
+        newAsteroid->speed =
+            Vector2Scale((Vector2){cosf(randomAngle), sinf(randomAngle)}, ASTEROID_SPEED * ((float)rand() / (float)RAND_MAX));
         newAsteroid->radius = AsteroidRadius(newAsteroid->sizeClass + 2);
         newAsteroid->active = true;
         newAsteroid->color = WHITE;
@@ -680,8 +679,7 @@ static void UpdateGame(void)
             }
 
             // asteroid logic
-            player.collider = (Vector3){player.position.x /* + cosf(player.rotation) * (shipHeight / 2.5f)*/,
-                                        player.position.y /* + sinf(player.rotation) * (shipHeight / 2.5f)*/, 12};
+            player.collider = (Vector3){player.position.x, player.position.y, 12};
             for (int i = 0; i < asteroids->size; i++) {
                 Asteroid *asteroid = (Asteroid *)xArray_get(asteroids, i);
                 if (!asteroid->active)

--- a/game/src/gameMain.c
+++ b/game/src/gameMain.c
@@ -536,7 +536,7 @@ static void InitGame(void)
 
     // initialization of player
     shipHeight = (PLAYER_BASE_SIZE / 2) / tanf(20 * DEG2RAD);
-    player.position = (Vector2){screenWidth / 2, screenHeight / 2 - shipHeight / 2};
+    player.position = (Vector2){(float)screenWidth / 2, (float)screenHeight / 2 - shipHeight / 2};
     player.speed = (Vector2){0, 0};
     player.acceleration = (Vector2){0, 0};
     player.rotation = -(PI / 2);

--- a/game/src/gameMain.c
+++ b/game/src/gameMain.c
@@ -180,7 +180,7 @@ int main(int argc, char *argv[])
         return 0;
     } else if (flags_cmd & CMD_FLAG_VERSION) {
         printf("Program:\t\tAsteroids-game\n");
-        printf("Version:\t\tDEV (P3.0)\n");
+        printf("Version:\t\t3.0a\n");
         printf("Compiler version:\t%s\n", __VERSION__);
         printf("Raylib version:\t\t%s\n", RAYLIB_VERSION);
         printf("Compiled on %s at %s\n", __DATE__, __TIME__);

--- a/manager/include/fnnGenAlgorithm.h
+++ b/manager/include/fnnGenAlgorithm.h
@@ -16,9 +16,8 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
-
-#include "fnnSerializer.h"
+#include <stdint.h>         // standard integer types (uint32_t, ...)
+#include "fnnSerializer.h"  // FNN model descriptor and serialization functions
 
 /**
  * @brief Generate randomized feedforward neural network model based on given parameters
@@ -59,8 +58,7 @@ FnnModel *fnn_generateModel(uint32_t *neuronCounts, FnnActivation_e *activationF
  *
  * @note The mutation is done using normal distribution around the current value.
  */
-FnnModel *fnn_modelBreed(FnnModel *parent1, FnnModel *parent2, float sbxCrossDistrIndex, float mutationRate,
-                            float mutationStddev);
+FnnModel *fnn_modelBreed(FnnModel *parent1, FnnModel *parent2, float sbxCrossDistrIndex, float mutationRate, float mutationStddev);
 
 /**
  * @brief Generate random weights for the FNN based on given layer neurons and range

--- a/manager/include/managerInstance.h
+++ b/manager/include/managerInstance.h
@@ -41,6 +41,7 @@ typedef struct {
     char *modelPath;      // path to the model file
     uint32_t generation;  // generation number
     float fitnessScore;   // fitness score
+    uint32_t currSeed;    // index of currently used seed of generation
 } managerInstance_t;
 
 /**
@@ -159,5 +160,12 @@ void mInstancer_setEpochSize(uint32_t value);
  * @param value Number of elite individuals (maximally population size - 1)
  */
 void mInstancer_setElitismCount(uint32_t value);
+
+/**
+ * @brief Set number of seeds to use for training single generation
+ *
+ * @param value Number of seeds (minimally 1)
+ */
+void mInstancer_setSeedCount(uint32_t value);
 
 #endif  // MANINSTANCE_H

--- a/manager/include/managerInstance.h
+++ b/manager/include/managerInstance.h
@@ -1,10 +1,9 @@
 #ifndef MANINSTANCE_H
 #define MANINSTANCE_H
 
-#include <inttypes.h>
-#include <unistd.h>
-
-#include "xArray.h"
+#include <inttypes.h>  // standard integer types (for fixed size integers)
+#include <unistd.h>    // standard symbolic constants and types (for POSIX OS API)
+#include "xArray.h"    // dynamic array structure
 
 #define FITNESS_WEIGHT_SCORE 0.5f
 #define FITNESS_WEIGHT_TIME 0.2f

--- a/manager/src/fnnGenAlgorithm.c
+++ b/manager/src/fnnGenAlgorithm.c
@@ -1,11 +1,9 @@
 #include "fnnGenAlgorithm.h"
-
-#include <math.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <time.h>
-
-#include "fnnSerializer.h"
+#include <math.h>           // mathematical functions (for pow, log, sqrt)
+#include <stdint.h>         // standard integer types (for uint8_t, uint32_t, ...)
+#include <stdlib.h>         // standard library (for malloc, free, rand)
+#include <time.h>           // time functions (for getting time)
+#include "fnnSerializer.h"  // FNN model implementation and serialization functions
 
 /**
  * @brief Generate random number from normal distribution
@@ -153,7 +151,8 @@ FnnModel *fnn_modelBreed(FnnModel *parent1, FnnModel *parent2, float sbxCrossDis
 
     // crossover
     if (parent1->weightValues != NULL && parent2->weightValues != NULL) {
-        float *childWeights = fnn_crossover(parent1->weightValues, parent2->weightValues, parent1->totalWeights, sbxCrossDistrIndex);
+        float *childWeights =
+            fnn_crossover(parent1->weightValues, parent2->weightValues, parent1->totalWeights, sbxCrossDistrIndex);
         if (childWeights == NULL) {
             fnn_free(child);
             return NULL;
@@ -183,7 +182,7 @@ FnnModel *fnn_modelBreed(FnnModel *parent1, FnnModel *parent2, float sbxCrossDis
     child->layerCount = parent1->layerCount;
     child->totalWeights = parent1->totalWeights;
     child->totalBiases = parent1->totalBiases;
-    
+
     child->neuronCounts = (uint32_t *)malloc(sizeof(uint32_t) * parent1->layerCount);
     if (child->neuronCounts == NULL) {
         fnn_free(child);

--- a/manager/src/managerInstance.c
+++ b/manager/src/managerInstance.c
@@ -1,23 +1,20 @@
 #include "managerInstance.h"
-
-#include <dirent.h>
-#include <fcntl.h>
-#include <inttypes.h>
-#include <pthread.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <unistd.h>
-
+#include <dirent.h>           // directory entry structure and functions
+#include <fcntl.h>            // file control options
+#include <inttypes.h>         // standard integer types
+#include <pthread.h>          // POSIX threads
+#include <stdio.h>            // standard I/O
+#include <stdlib.h>           // standard library
+#include <sys/stat.h>         // file status
+#include <sys/types.h>        // data types
+#include <sys/wait.h>         // waitpid (for child process termination)
+#include <unistd.h>           // standard symbolic constants and types
 #include "commonUtility.h"    // common utility functions
 #include "fnnGenAlgorithm.h"  // feedforward neural network genetic algorithm functions
 #include "fnnSerializer.h"    // feedforward neural network model serialization functions
 #include "sharedMemory.h"     // shared memory functions
 #include "xArray.h"           // dynamic array structure and functions
 #include "xDictionary.h"      // dictionary structure and functions
-#include "xString.h"          // dynamic string structure and functions
 
 //------------------------------------------------------------------------------------
 // program globals

--- a/manager/src/managerInstance.c
+++ b/manager/src/managerInstance.c
@@ -798,6 +798,9 @@ static void *thr_instanceStarter(void *arg)
                     waitpid(instance->gamePID, NULL, 0);
                     waitpid(instance->aiPID, NULL, 0);
 
+                    instance->gamePID = -1;
+                    instance->aiPID = -1;
+
                     // update instance status
                     instance->currSeed = instance->currSeed + 1;
                     if (instance->status & INSTANCE_ERRORED) {

--- a/manager/src/managerInstance.c
+++ b/manager/src/managerInstance.c
@@ -784,9 +784,9 @@ static void *thr_instanceStarter(void *arg)
                         sm_lockSharedState(shStat);
                         if (shStat->game_isOver) {
                             instance->status = INSTANCE_FINISHED;
-                            instance->fitnessScore += shStat->game_gameScore * FITNESS_WEIGHT_SCORE +
-                                                      shStat->game_gameTime * FITNESS_WEIGHT_TIME +
-                                                      shStat->game_gameLevel * FITNESS_WEIGHT_LEVEL;
+                            instance->fitnessScore +=
+                                (shStat->game_gameScore * FITNESS_WEIGHT_SCORE + shStat->game_gameTime * FITNESS_WEIGHT_TIME +
+                                 shStat->game_gameLevel * FITNESS_WEIGHT_LEVEL) / randSeedCount;
                             shStat->control_gameExit = true;
                             shStat->control_neuronsExit = true;
                         }
@@ -807,7 +807,6 @@ static void *thr_instanceStarter(void *arg)
                         instance->status = INSTANCE_ERRENDED;
                     } else {
                         if (instance->currSeed >= randSeedCount) {
-                            instance->fitnessScore /= (float)randSeedCount;
                             instance->status = INSTANCE_ENDED;
                         } else {
                             instance->status = INSTANCE_WAITING;

--- a/manager/src/managerShell.c
+++ b/manager/src/managerShell.c
@@ -1,19 +1,17 @@
-#include "managerInstance.h"  // instance manager module
-
-#include <dirent.h>     // directory operations
-#include <pthread.h>    // POSIX threads (worker threads)
-#include <stdint.h>     // standard integer types
-#include <stdio.h>      // standard input/output
-#include <sys/stat.h>   // data returned by the stat() function
-#include <sys/types.h>  // unix data types
-#include <sys/wait.h>   // waitpid function
-#include <time.h>       // time types
-#include <unistd.h>     // standard symbolic constants and types
-
+#include <dirent.h>           // directory operations
+#include <pthread.h>          // POSIX threads (worker threads)
+#include <stdint.h>           // standard integer types
+#include <stdio.h>            // standard input/output
+#include <stdlib.h>           // standard library
+#include <sys/stat.h>         // data returned by the stat() function
+#include <sys/types.h>        // unix data types
+#include <sys/wait.h>         // waitpid function
+#include <time.h>             // time types
+#include <unistd.h>           // standard symbolic constants and types
 #include "commonUtility.h"    // common utility functions
 #include "fnnGenAlgorithm.h"  // genetic algorithm functions for feedforward neural network (FNN) weights and biases
 #include "fnnSerializer.h"    // neural network model reading and writing
-#include "sharedMemory.h"     // shared memory functions
+#include "managerInstance.h"  // instance manager module
 #include "xArray.h"           // dynamic array and its functions
 #include "xDictionary.h"      // treemap and its functions
 #include "xString.h"          // string functions

--- a/manager/src/managerShell.c
+++ b/manager/src/managerShell.c
@@ -297,7 +297,7 @@ int cmd_help(void)
 int cmd_version(void)
 {
     printf("\tProgram:\t\tAstroMGR\n"
-           "\tVersion:\t\tDEV (P3.0)\n"
+           "\tVersion:\t\t3.0a\n"
            "\tCompiler version:\t"__VERSION__
            "\n"
            "\tCompiled on %s at %s\n",

--- a/neurons/include/fnnLoader.h
+++ b/neurons/include/fnnLoader.h
@@ -18,8 +18,6 @@ extern "C" {
 #endif
 
 #include <stdint.h>
-
-#include "fnnSerializer.h"
 #include "xList.h"
 
 /**

--- a/neurons/src/fnnLoader.c
+++ b/neurons/src/fnnLoader.c
@@ -1,8 +1,7 @@
 #include "fnnLoader.h"
-
-#include <stdint.h>  // universal integer types
-#include <stdio.h>   // fprintf (for error messages)
-
+#include <stdint.h>         // universal integer types
+#include <stdio.h>          // fprintf (for error messages)
+#include <stdlib.h>         // malloc (for memory allocation)
 #include "fnnSerializer.h"  // FNN model descriptor
 #include "xLinear.h"        // xMatrix objects for layer information
 #include "xList.h"          // xList object for storing xMatrix objects in one package for return

--- a/neurons/src/neuronsMain.c
+++ b/neurons/src/neuronsMain.c
@@ -1,18 +1,15 @@
-#include "neuronsMain.h"  // neural network program related enums, structs, etc.
-
-#include <math.h>     // math functions
-#include <signal.h>   // signal handling (will be used for graceful exit)
-#include <stdbool.h>  // boolean type
-#include <stdio.h>    // console input/output
-#include <stdlib.h>   // malloc, free, etc.
-#include <time.h>     // time functions (for random number generation)
-
-#include "commonUtility.h"  // common utility functions
-#include "fnnLoader.h"      // feedforward neural network loader (.fnnm file format)
-#include "sharedMemory.h"   // shared memory
-#include "xLinear.h"        // matrix operations
-#include "xList.h"          // list structure and operations
-#include "xString.h"        // string operations (for parsing command line arguments)
+#include "neuronsMain.h"
+#include <math.h>          // math functions
+#include <signal.h>        // signal handling (will be used for graceful exit)
+#include <stdbool.h>       // boolean type
+#include <stdio.h>         // console input/output
+#include <stdlib.h>        // malloc, free, etc.
+#include <time.h>          // time functions (for random number generation)
+#include "fnnLoader.h"     // feedforward neural network loader (.fnnm file format)
+#include "sharedMemory.h"  // shared memory
+#include "xLinear.h"       // matrix operations
+#include "xList.h"         // list structure and operations
+#include "xString.h"       // string operations (for parsing command line arguments)
 
 // ----------------------------------------------------------------------------------------------
 // global variables

--- a/neurons/src/neuronsMain.c
+++ b/neurons/src/neuronsMain.c
@@ -163,7 +163,7 @@ int main(int argc, char *argv[])
         return 0;
     } else if (flags_cmd & CMD_FLAG_VERSION) {
         printf("Program:\t\tAsteroids-Neurons\n");
-        printf("Version:\t\tDEV P3.0\n");
+        printf("Version:\t\t3.0a\n");
         printf("Compiler version:\t%s\n", __VERSION__);
         printf("Compiled on %s at %s\n", __DATE__, __TIME__);
         return 0;

--- a/neurons/src/xLinear.c
+++ b/neurons/src/xLinear.c
@@ -1,7 +1,6 @@
 #include "xLinear.h"
-
-#include <stdint.h>
-#include <stdlib.h>
+#include <stdint.h>  // universal integer types
+#include <stdlib.h>  // standard library (for malloc, free)
 
 xMatrix *xMatrix_new(uint32_t rows, uint32_t cols)
 {


### PR DESCRIPTION
This pull request includes several updates and improvements to the codebase:

- The build system has been updated to reduce redundant compilation calls between targets.

- Clangd LSP related files and directories are now ignored.

- All header inclusions have been refactored and short comments have been added to describe why they are included.

- The player rotation pivot point has been moved to the center of its shape, and the minimum distance calculation has been updated to calculate between collider edges instead of centers.

- Training on multiple seeds has been added before evaluating generation fitness.

- The game and neurons PID are now reset to -1 when they finish running for clarity in `genstat` output of manager shell.

- The initial asteroid velocity is now randomized.

- Added new evolution strategy which uses multiple random seeds for evaluating single generation fitness.

- The version printout has been updated.

These changes aim to improve the build process, optimize the codebase, and enhance the game mechanics.