### PR TITLE
Introduced autokill mechanism

### DIFF
--- a/manager/include/managerInstance.h
+++ b/manager/include/managerInstance.h
@@ -13,7 +13,7 @@
 #define BREED_MUTATION_RATE 0.1f
 #define BREED_MUTATION_STDDEV 0.1f
 
-#define AUTOKILL_TIMEOUT 60  // timeout in seconds before killing instance if no score update happens
+#define AUTOKILL_TIMEOUT 20  // timeout in seconds before killing instance if no score update happens
 
 enum instanceStatus_e {
     INSTANCE_INACTIVE = 0x00,

--- a/manager/include/managerInstance.h
+++ b/manager/include/managerInstance.h
@@ -13,6 +13,8 @@
 #define BREED_MUTATION_RATE 0.1f
 #define BREED_MUTATION_STDDEV 0.1f
 
+#define AUTOKILL_TIMEOUT 60  // timeout in seconds before killing instance if no score update happens
+
 enum instanceStatus_e {
     INSTANCE_INACTIVE = 0x00,
     INSTANCE_WAITING = 0x01,
@@ -32,6 +34,9 @@ typedef struct {
 
     pid_t gamePID;  // game process ID
     pid_t aiPID;    // AI process ID
+
+    int scoreUpdateValue;    // last updated score value
+    long scoreUpdateTime;  // time of updating score
 
     // uint32_t sharedMemoryID;  // shared memory ID
     char shmemInput[255];   // input shared memory key

--- a/manager/src/managerShell.c
+++ b/manager/src/managerShell.c
@@ -297,7 +297,7 @@ int cmd_help(void)
 int cmd_version(void)
 {
     printf("\tProgram:\t\tAstroMGR\n"
-           "\tVersion:\t\t3.0a\n"
+           "\tVersion:\t\t3.1\n"
            "\tCompiler version:\t"__VERSION__
            "\n"
            "\tCompiled on %s at %s\n",


### PR DESCRIPTION
This pull request adds an autokill mechanism to timeout instances that exploit inactivity and stall evaluation. The timeout has been set to 20 seconds to encourage evolving a more aggressive playstyle overall. Additionally, the manager version has been bumped to 3.1.